### PR TITLE
Add PatchType.

### DIFF
--- a/src/serialization/format_version.rs
+++ b/src/serialization/format_version.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use xmltree::Element;
 
-use super::{keys, xml};
+use super::{keys, xml, version_info::PatchType};
 
 /// Deluge format version
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -67,7 +67,7 @@ fn check_for_version(text: &str, expected_first_char: char) -> bool {
     }
 }
 
-pub fn detect_format_version(roots: &[Element], element_type: &str) -> Option<FormatVersion> {
+pub fn detect_format_version(roots: &[Element], patch_type: PatchType) -> Option<FormatVersion> {
     // Notice we check the newest versions first, but this is because version 1 does not contains any version infos.
     let functions: Vec<(VersionFunctionDetection, FormatVersion)> = vec![
         (is_version_3, FormatVersion::Version3),
@@ -75,8 +75,10 @@ pub fn detect_format_version(roots: &[Element], element_type: &str) -> Option<Fo
         (is_version_1, FormatVersion::Version1),
     ];
 
+    let key = patch_type.get_key();
+
     for f in &functions {
-        if f.0(roots, element_type) {
+        if f.0(roots, key) {
             return Some(f.1);
         }
     }
@@ -92,12 +94,12 @@ mod tests {
 
     /// This helper exists to avoid having to change each test, but it's legacy.
     fn detect_kit_format_version(roots: &[Element]) -> Result<FormatVersion, Error> {
-        detect_format_version(roots, keys::KIT).ok_or(Error::InvalidVersionFormat)
+        detect_format_version(roots, PatchType::Kit).ok_or(Error::InvalidVersionFormat)
     }
 
     /// This helper exists to avoid having to change each test, but it's legacy.
     fn detect_synth_format_version(roots: &[Element]) -> Result<FormatVersion, Error> {
-        detect_format_version(roots, keys::SOUND).ok_or(Error::InvalidVersionFormat)
+        detect_format_version(roots, PatchType::Synth).ok_or(Error::InvalidVersionFormat)
     }
 
     #[test]

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -1,6 +1,6 @@
 use crate::{Error, Kit, Synth};
 
-use self::version_info::VersionInfo;
+use self::version_info::{PatchType, VersionInfo};
 
 mod default_params;
 mod format_version;
@@ -19,7 +19,7 @@ pub fn load_kit(xml: &str) -> Result<Kit, Error> {
 
 pub fn load_kit_with_version(xml: &str) -> Result<(Kit, VersionInfo), Error> {
     let roots = xml::load_xml(xml)?;
-    let version_info = version_info::load_version_info(&roots, keys::KIT);
+    let version_info = version_info::load_version_info(&roots, PatchType::Kit);
     let kit = match version_info.format_version {
         format_version::FormatVersion::Version3 => serialization_v3::load_kit_nodes(&roots)?,
         format_version::FormatVersion::Version2 => serialization_v2::load_kit_nodes(&roots)?,
@@ -37,7 +37,7 @@ pub fn load_synth(xml: &str) -> Result<Synth, Error> {
 
 pub fn load_synth_with_version(xml: &str) -> Result<(Synth, VersionInfo), Error> {
     let roots = xml::load_xml(xml)?;
-    let version_info = version_info::load_version_info(&roots, keys::SOUND);
+    let version_info = version_info::load_version_info(&roots, PatchType::Synth);
     let synth = match version_info.format_version {
         format_version::FormatVersion::Version3 => serialization_v3::load_synth_nodes(&roots)?,
         format_version::FormatVersion::Version2 => serialization_v2::load_synth_nodes(&roots)?,


### PR DESCRIPTION
This enum prevent the error where you mistype the key of the root node (kit or sound).